### PR TITLE
Fix filter with a string that starts with a number

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,10 +26,12 @@ module.exports = class ServerTrailpack extends Trailpack {
       if (value === '%00' || value === 'null') {
         value = null
       }
+
       const parseValue = parseFloat(value)
-      if (!isNaN(parseValue)) {
+      if (!isNaN(parseValue) && isFinite(value)) {
         value = parseValue
       }
+
       return value
     })
   }


### PR DESCRIPTION
If the query criteria starts with a number, but contains non numeric characters (5000asdf) it should't be parsed as a float